### PR TITLE
Fix gMSA name regex

### DIFF
--- a/gMSA Audit
+++ b/gMSA Audit
@@ -147,7 +147,7 @@ $results = New-Object System.Collections.Generic.List[object]
 foreach($g in $gmsas){
   $gName = $g.Name.TrimEnd('$')
   $sam  = $g.SamAccountName   # Typically ends with $
-  $idPattern = "(?i)^(?:$netbios\\)?$([Regex]::Escape($gName))\$$"
+  $idPattern = "(?i)^(?:{0}\)?{1}\$" -f [Regex]::Escape($netbios), [Regex]::Escape($gName)
 
   Write-Info "Scanning usage for gMSA: $sam ..."
   $allowed = ($g.PrincipalsAllowedToRetrieveManagedPassword | ForEach-Object {


### PR DESCRIPTION
## Summary
- fix gMSA audit regex to correctly escape domain prefix and trailing dollar

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Output test"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a63eed3628832ebc4bab817c8a24df