### PR TITLE
Rename Write-Err helper to Write-Error

### DIFF
--- a/gMSA Audit
+++ b/gMSA Audit
@@ -23,7 +23,7 @@ param(
 #--- Helpers ---------------------------------------------------------------
 function Write-Info($msg){ Write-Host "[*] $msg" }
 function Write-Warn($msg){ Write-Warning $msg }
-function Write-Err ($msg){ Write-Host "[X] $msg" -ForegroundColor Red }
+function Write-Error ($msg){ Write-Host "[X] $msg" -ForegroundColor Red }
 
 function Resolve-ComputerMembers {
   param([Parameter(Mandatory)][System.Collections.IEnumerable]$Principals)


### PR DESCRIPTION
## Summary
- rename helper Write-Err to Write-Error in gMSA Audit

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('gMSA Audit',[ref]$null,[ref]$null) | Out-Null"` *(command not found: pwsh)*
- `apt-get update` *(403 errors fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a64061c0c4832eb3c99370dfe6fe00