### PR TITLE
Add Pester test for Resolve-ComputerMembers

### DIFF
--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -1,0 +1,2 @@
+param()
+Invoke-Pester -Path (Join-Path $PSScriptRoot 'tests') -CI

--- a/tests/Resolve-ComputerMembers.Tests.ps1
+++ b/tests/Resolve-ComputerMembers.Tests.ps1
@@ -1,0 +1,50 @@
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'gMSA Audit'
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$tokens, [ref]$parseErrors)
+    if ($parseErrors) { throw ($parseErrors | Out-String) }
+    $funcAst = $ast.Find({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Resolve-ComputerMembers' }, $true)
+    . ([ScriptBlock]::Create($funcAst.Extent.Text))
+}
+
+Describe 'Resolve-ComputerMembers' {
+    It 'returns unique computer names from nested group hierarchy' {
+        $directory = @{
+            'CN=GroupA,DC=example,DC=com' = @{ ObjectClass = 'group'; Members = @('CN=GroupB,DC=example,DC=com','CN=Comp1,DC=example,DC=com','CN=Comp2,DC=example,DC=com') }
+            'CN=GroupB,DC=example,DC=com' = @{ ObjectClass = 'group'; Members = @('CN=GroupC,DC=example,DC=com','CN=Comp2,DC=example,DC=com') }
+            'CN=GroupC,DC=example,DC=com' = @{ ObjectClass = 'group'; Members = @('CN=Comp3,DC=example,DC=com') }
+            'CN=Comp1,DC=example,DC=com' = @{ ObjectClass = 'computer'; DNSHostName = 'comp1.example.com' }
+            'CN=Comp2,DC=example,DC=com' = @{ ObjectClass = 'computer'; DNSHostName = 'comp2.example.com' }
+            'CN=Comp3,DC=example,DC=com' = @{ ObjectClass = 'computer'; DNSHostName = 'comp3.example.com' }
+        }
+
+        Mock Get-ADObject {
+            param($Identity)
+            if ($Identity -isnot [string]) { $Identity = $Identity.DistinguishedName }
+            $entry = $directory[$Identity]
+            [pscustomobject]@{
+                DistinguishedName = $Identity
+                objectClass = $entry.ObjectClass
+            }
+        }
+
+        Mock Get-ADGroupMember {
+            param($Identity)
+            $directory[$Identity].Members
+        }
+
+        Mock Get-ADComputer {
+            param($Identity)
+            $entry = $directory[$Identity]
+            [pscustomobject]@{
+                DNSHostName = $entry.DNSHostName
+                Name = $entry.DNSHostName.Split('.')[0]
+            }
+        }
+
+        $results = Resolve-ComputerMembers -Principals @('CN=GroupA,DC=example,DC=com')
+
+        $results | Should -Be @('comp1.example.com','comp2.example.com','comp3.example.com')
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester test for Resolve-ComputerMembers verifying unique computer names with nested AD mocks
- add RunTests.ps1 script to run the tests

## Testing
- `pwsh -NoProfile -File RunTests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a640656808832ebeb5ba2290fc4e83